### PR TITLE
Add isHidden flag to hide phrases in learning mode (#36)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "learn-phrases",
-  "version": "3.2.6",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "learn-phrases",
-      "version": "3.2.6",
+      "version": "3.4.0",
       "dependencies": {
         "@octokit/core": "^6.1.4",
         "react": "^18.3.1",
@@ -31,7 +31,7 @@
         "rollup-plugin-visualizer": "^5.12.0",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
-        "vite": "^6.2.3"
+        "vite": "^6.2.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3577,6 +3577,54 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3715,15 +3763,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
-        "rollup": "^4.30.1"
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3784,6 +3835,37 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/which": {

--- a/src/components/EditPhraseForm/EditPhraseForm.css
+++ b/src/components/EditPhraseForm/EditPhraseForm.css
@@ -33,3 +33,8 @@
   gap: 0.8em;
   margin-left: auto;
 }
+
+.edit-phrase-form__hide {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}

--- a/src/components/EditPhraseForm/EditPhraseForm.tsx
+++ b/src/components/EditPhraseForm/EditPhraseForm.tsx
@@ -11,6 +11,7 @@ import { useMainContext, useNotificationContext } from '../../hooks';
 import { InputText, InputTextHandle } from '../InputText/InputText';
 import { Rating } from '../Rating/Rating';
 import { Confirm } from '../Confirm/Confirm';
+import { InputCheckbox } from '../InputCheckbox/InputCheckbox';
 
 interface EditPhraseFormProps {
   phrase?: Partial<Phrase>;
@@ -30,7 +31,7 @@ export function EditPhraseForm(data: EditPhraseFormProps) {
 
   const isEdit = !!phrase?.id;
 
-  const onPhraseFieldChange = (name: string, value: string | number) => {
+  const onPhraseFieldChange = (name: string, value: string | number | boolean) => {
     setNowPhrase((prev) => ({ ...prev, [name]: value }));
   };
 
@@ -148,6 +149,17 @@ export function EditPhraseForm(data: EditPhraseFormProps) {
             level={phrase?.knowledgeLvl}
             onChange={(value) => onPhraseFieldChange('knowledgeLvl', value)}
           />
+        </div>
+
+        <div className="edit-phrase-form__hide">
+          <InputCheckbox
+            name="isHidden"
+            key={`${phrase?.id}-isHidden`}
+            initialChecked={phrase?.isHidden}
+            onChange={(checked) => onPhraseFieldChange('isHidden', checked)}
+          >
+            Hide this phrase in learning mode.
+          </InputCheckbox>
         </div>
 
         <div className="edit-phrase-form__footer">

--- a/src/components/PhrasesTable/PhrasesTable.css
+++ b/src/components/PhrasesTable/PhrasesTable.css
@@ -51,6 +51,10 @@ tr:focus-visible .phrases-table__cell--first {
   box-shadow: inset 0 0 0 2px var(--black);
 }
 
+.phrases-table__cell--hidden {
+  text-align: center;
+}
+
 .phrases-table__no-phrases {
   padding: 2em;
   font-size: var(--text-size-xl);

--- a/src/components/PhrasesTable/PhrasesTable.tsx
+++ b/src/components/PhrasesTable/PhrasesTable.tsx
@@ -28,6 +28,7 @@ export function PhrasesTable(data: PhrasesTableProps) {
               <col />
               <col style={{ width: '40px' }} />
               <col style={{ width: '100px' }} />
+              <col style={{ width: '36px' }} />
               {/* <col style={{ width: "300px" }} /> */}
             </colgroup>
 
@@ -47,6 +48,13 @@ export function PhrasesTable(data: PhrasesTableProps) {
                 </th>
                 <th className="phrases-table__cell" scope="col">
                   Created
+                </th>
+                <th
+                  className="phrases-table__cell  phrases-table__cell--hidden"
+                  scope="col"
+                  title="Hidden in learning mode"
+                >
+                  H
                 </th>
                 {/* <th className="phrases-table__cell" scope="col">Tags</th> */}
               </tr>
@@ -75,6 +83,12 @@ export function PhrasesTable(data: PhrasesTableProps) {
                   </td>
                   <td className="phrases-table__cell">{phrase.knowledgeLvl}</td>
                   <td className="phrases-table__cell">{formatDate(phrase.createDate)}</td>
+                  <td
+                    className="phrases-table__cell  phrases-table__cell--hidden"
+                    title={phrase.isHidden ? 'Hidden in learning mode' : undefined}
+                  >
+                    {phrase.isHidden ? '●' : ''}
+                  </td>
                   {/* <td className="phrases-table__cell">{phrase.tags?.join(', ')}</td> */}
                 </tr>
               ))}

--- a/src/pages/Learn/Learn.tsx
+++ b/src/pages/Learn/Learn.tsx
@@ -195,6 +195,7 @@ export default function Learn() {
     const calculatedUnlearnedIDs: Set<Phrase['id']> = new Set();
 
     allPhrases?.forEach((phrase) => {
+      if (phrase.isHidden) return;
       if (phrase.knowledgeLvl >= 9) {
         calculatedLearnedIDs.add(phrase.id);
         return;

--- a/src/services/adapters/getPhraseDTOFromPhrase.ts
+++ b/src/services/adapters/getPhraseDTOFromPhrase.ts
@@ -24,6 +24,7 @@ export const getPhraseDTOFromPhrase = (data: Phrase): PhraseDTO | null => {
     data.knowledgeLvl ?? 0,
     data.createDate,
     data.tags.join(',') ?? '',
+    data.isHidden ?? false,
   ];
 
   return newPhraseDTO;

--- a/src/services/adapters/getPhraseFromPhraseDTO.ts
+++ b/src/services/adapters/getPhraseFromPhraseDTO.ts
@@ -36,6 +36,7 @@ export const getPhraseFromPhraseDTO = (data: unknown): Partial<Phrase> | null =>
     knowledgeLvl,
     createDate,
     tags: data?.[7],
+    isHidden: data?.[8] === true,
   };
 
   return getValidatedPhrase(newPhrase, true);

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type PhraseDTO = [
   KnowledgeLvl,
   Phrase['createDate'],
   string, // Phrase['tags'],
+  boolean, // Phrase['isHidden'],
 ];
 export interface Phrase {
   id: number;
@@ -36,6 +37,7 @@ export interface Phrase {
   knowledgeLvl: KnowledgeLvl;
   createDate: string;
   tags: string[];
+  isHidden?: boolean;
 }
 export interface Replacement {
   search: RegExp;

--- a/src/utils/arePhrasesDifferent.ts
+++ b/src/utils/arePhrasesDifferent.ts
@@ -11,6 +11,7 @@ export const arePhrasesDifferent = (phrase1: Partial<Phrase>, phrase2: Partial<P
     'second',
     'secondD',
     'knowledgeLvl',
+    'isHidden',
     // 'createDate',
   ];
 

--- a/src/utils/getValidatedPhrase.ts
+++ b/src/utils/getValidatedPhrase.ts
@@ -35,6 +35,7 @@ export const getValidatedPhrase = (
     knowledgeLvl: convertToKnowledgeLvl(phrase.knowledgeLvl),
     createDate,
     tags,
+    isHidden: phrase.isHidden === true,
   };
 
   if (idIsRequired) {


### PR DESCRIPTION
- Add `isHidden` field to `Phrase` type and `PhraseDTO` tuple (index 8)
- Add checkbox "Hide this phrase in learning mode" to EditPhraseForm
- Filter out hidden phrases in Learn page when building learnedIDs/unlearnedIDs
- Show hidden status indicator (●) in PhrasesTable admin column
- Update DTO adapters (getPhraseDTOFromPhrase, getPhraseFromPhraseDTO) to serialize/deserialize isHidden
- Update getValidatedPhrase and arePhrasesDifferent utilities to handle isHidden